### PR TITLE
fix: escape regex special characters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,10 @@ const parseMatchedTextNode = (regexp: RegExp, node: ChildNode, style?: string) =
 }
 
 const highlightElements = (el: HTMLElement, value: Array<string>, style?: string) => {
+
+  // escape regex special characters (similar to preg_quote in PHP)
+  value = value.map(val => val.replace(/[-[\]{}()*+?.,\\^$|#\s]/ig, "\\$&"))
+  
   const regexp = new RegExp(value.join("|"), "gi");
 
   if (!el.textContent?.match(regexp)) {


### PR DESCRIPTION
a search term like `**Recruitement**` will crash because the `*` are special cheracters in regex

this fix is about escaping all the regex special characters before running the search 